### PR TITLE
Add mappings for Dai and Gem transfers

### DIFF
--- a/mappings/dai_transfer.yml
+++ b/mappings/dai_transfer.yml
@@ -1,0 +1,26 @@
+--- # Mappings of Dai Transfer values from events
+- Drip.Drip:
+    src: Drip.ilk,
+    dst: nil,
+    amt: Drip.diff,
+    act: 'drip'
+    tx: log.TxHash
+- Vat.heal: {
+    src: nil,
+    dst: heal.v,
+    amt: heal.rad,
+    act: 'heal'
+    tx: log.TxHash
+- Vat.move:
+    src: move.src,
+    dst: move.dst,
+    amt: move.rad,
+    act: 'move'
+    tx: log.TxHash
+- Vat.tune:
+    src: nil,
+    dst: tune.u,
+    amt: tune.dart,
+    act: 'tune'
+    tx: log.TxHash
+...

--- a/mappings/dai_transfer.yml
+++ b/mappings/dai_transfer.yml
@@ -1,26 +1,26 @@
 --- # Mappings of Dai Transfer values from events
-- Drip.Drip:
-    src: Drip.ilk,
-    dst: nil,
-    amt: Drip.diff,
-    act: 'drip'
-    tx: log.TxHash
-- Vat.heal: {
-    src: nil,
-    dst: heal.v,
-    amt: heal.rad,
-    act: 'heal'
-    tx: log.TxHash
-- Vat.move:
-    src: move.src,
-    dst: move.dst,
-    amt: move.rad,
-    act: 'move'
-    tx: log.TxHash
-- Vat.tune:
-    src: nil,
-    dst: tune.u,
-    amt: tune.dart,
-    act: 'tune'
-    tx: log.TxHash
+- Drip.Drip(bytes32 indexed ilk, uint256 Art, uint256 rate, int256 diff, uint48 rho):
+    src:  Drip.ilk,
+    dst:  nil,
+    amt:  Drip.diff,
+    act:  'drip'
+    tx:   log.TxHash
+- Vat.heal(bytes32 u, bytes32 v, int rad):
+    src:  nil,
+    dst:  heal.v,
+    amt:  heal.rad,
+    act:  'heal'
+    tx:   log.TxHash
+- Vat.move(bytes32 src, bytes32 dst, int256 rad):
+    src:  move.src,
+    dst:  move.dst,
+    amt:  move.rad,
+    act:  'move'
+    tx:   log.TxHash
+- Vat.tune(bytes32 i, bytes32 u, bytes32 v, bytes32 w, int dink, int dart):
+    src:  nil,
+    dst:  tune.u,
+    amt:  tune.dart,
+    act:  'tune'
+    tx:   log.TxHash
 ...

--- a/mappings/gem_transfer.yml
+++ b/mappings/gem_transfer.yml
@@ -1,0 +1,37 @@
+--- # Mappings of Gem Transfer values from events
+- Vat.flux(bytes32 ilk, bytes32 src, bytes32 dst, int256 rad):
+    src:  flux.src
+    dst:  flux.dst
+    ilk:  flux.ilk
+    amt:  flux.rad
+    act:  'flux'
+    tx:   log.TxHash
+- Vat.grab(bytes32 i, bytes32 u, bytes32 v, bytes32 w, int dink, int dart):
+    src:  grab.u
+    dst:  grab.v
+    ilk:  grab.i
+    amt:  Ilks[grab.i] * grab.dink
+    act:  'grab'
+    tx:   log.TxHash
+- Vat.slip(bytes32 ilk, bytes32 guy, int256 rad):
+    src:  msg.sender (adapter)
+    dst:  slip.guy
+    ilk:  slip.ilk
+    amt:  slip.rad
+    act:  'slip'
+    tx:   log.TxHash
+- Vat.toll(bytes32 i, bytes32 u, int take):
+    src:  nil
+    dst:  toll.u
+    ilk:  toll.i
+    amt:  Ilks[toll.i] * toll.take
+    act:  'toll'
+    tx:   log.TxHash
+- Vat.tune(bytes32 i, bytes32 u, bytes32 v, bytes32 w, int dink, int dart):
+    src:  tune.v
+    dst:  tune.v
+    ilk:  tune.i
+    amt:  Ilks[tune.i] * tune.dink
+    act:  'tune'
+    tx:   log.TxHash
+...

--- a/transfer.graphql
+++ b/transfer.graphql
@@ -12,7 +12,7 @@ enum DaiAct {
   MOVE
   TUNE
   HEAL
-  FOLD
+  DRIP
 }
 
 # Vat Gem movements


### PR DESCRIPTION
Opening this up as a place to discuss mapping events to views for dai and gem transfers. A few points worth clarifying:
- I think we may want to append the `vow` to the `Drip` event and use that as our `dst`? If so, I imagine we could set the `src` to `nil`?
- replaced `Tx` metadata with the log's `TxHash` for ease of populating the data. Not currently persisting full transaction meta but we can tackle that if necessary.
- Deriving the `amt` values for gem transfers originating out of `grab`, `toll`, and `tune` events currently requires a separate lookup of the `ilk`. It would be great if there were some way to derive this from the event itself (as we did with replacing `fold` with `Drip`).
- There's a similar concern with the `src` on `slip` (`msg.sender`) - this could be further justification for persisting transaction meta if we'd definitely like to have that there.