### PR TITLE
Bid mapping

### DIFF
--- a/mappings/bid-event.yml
+++ b/mappings/bid-event.yml
@@ -1,0 +1,100 @@
+- Flip.kick:
+    bidId: flip_kick.bid_id
+    act:   'KICK'
+    lot:   flip_kick.log
+    bid:   flip_kick.bid
+    guy:   null #msg.sender
+    tic:   null
+    end:   flip_kick.end
+    tx:    log.TxHash
+
+- Flip.tend:
+    bidId: tend.bid_id
+    act:   'TEND'
+    lot:   tend.log
+    bid:   tend.bid
+    guy:   tend.guy
+    tic:   tend.tic
+    end:   null
+    tx:    log.TxHash
+
+- Flip.dent:
+    bidId: dent.bid_id
+    act:   'DENT'
+    lot:   dent.lot
+    bid:   dent.bid
+    guy:   dent.guy
+    tic:   dent.tic
+    end:   null
+    tx:    log.TxHash
+
+
+- Flip.deal:
+    bidId: deal.bid_id
+    act:   'DEAL'
+    lot:   null
+    bid:   null
+    guy:   null #msg.sender
+    tic:   null
+    end:   null
+    tx:    log.TxHash
+
+- Flop.kick:
+    bidId: flop_kick.bid_id
+    act:   'KICK'
+    lot:   flop_kick.lot
+    bid:   flop_kick.bid
+    guy:   null #msg.sender
+    tic:   null
+    end:   flop_kick.end
+    tx:    log.TxHash
+
+- Flop.dent:
+    bidId: dent.bid_id
+    act:   'DENT'
+    lot:   dent.lot
+    bid:   dent.bid
+    guy:   dent.guy
+    tic:   dent.tic
+    end:   null
+    tx:    log.TxHash
+
+- Flop.deal:
+    bidId: deal.bid_id
+    act:   'DEAL'
+    lot:   null
+    bid:   null
+    guy:   null #msg.sender
+    tic:   null
+    end:   null
+    tx:    log.TxHash
+
+- Flap.kick:
+    bidId: flap_kick.bid_id
+    act:   'KICK'
+    lot:   flap_kick.lot
+    bid:   flap_kick.bid
+    guy:   null #msg.sender
+    tic:   null
+    end:   flap_kick.end
+    tx:    log.TxHash
+
+- Flap.tend:
+    bidId: tend.bid_id
+    act:   'TEND'
+    lot:   tend.lot
+    bid:   tend.bid
+    guy:   tend.guy
+    tic:   tend.tic
+    end:   null
+    tx:    log.TxHash
+
+- Flap.deal:
+    bidId: deal.bid_id
+    act:   'DEAL'
+    lot:   null
+    bid:   null
+    guy:   null #msg.sender
+    tic:   null
+    end:   null
+    tx:    log.TxHash

--- a/mappings/bid.yml
+++ b/mappings/bid.yml
@@ -1,0 +1,41 @@
+- FlipBid:
+    id:      flip_kick.bid_id
+    guy:     tend[id].guy OR dent[id].guy
+    tic:     tend[id].tic OR dent[id].tic
+    end:     flip_kick.end
+    lot:     flip_kick.lot OR tend[id].lot OR dent[id].lot
+    bid:     flip_kick.bid OR tend[id].bid OR dent[id].bid
+    gal:     flip_kick.gal
+    urn:     flip_kick.urn
+    tab:     flip_kick.tab
+    dealt:   deal[bid_id] != null
+    market:  Market     # market detail
+    type:    'FLIP'
+
+- FlopBid:
+    id:      flop_kick.bid_id
+    guy:     dent[id].guy
+    tic:     dent[id].guy
+    end:     flop_kick.end
+    lot:     flop_kick.lot
+    bid:     flop_kick.bid
+    gal:     flop_kick.gal
+    urn:     null
+    tab:     null
+    dealt:   deal[id] != null
+    market:  Market     # market detail
+    type:    'FLOP'
+
+- FlapBid:
+    id:      flap_kick.bid_id
+    guy:     tend[id].guy
+    tic:     tend[id].tic
+    end:     flap_kick.end
+    lot:     flap_kick.lot
+    bid:     flap_kick.bid
+    gal:     flap_kick.gal
+    urn:     null
+    tab:     null
+    dealt:   deal[id] != null
+    market:  Market     # market detail
+    type:    'FLAP'


### PR DESCRIPTION
a couple of notes/questions:

- for `kick` and `deal` for each of the auction types, the emitted events don't include `msg.sender` which is necessary for `guy`

- would it be helpful to include the BidType on each of the BidEvents?

- I was understanding a `Bid` as an accumulated view of how each `BidEvent` affects the specific bid. Could you elaborate on the difference between the `allBids` query, and the `allBidStates` query? It looks like they both return a collection of `Bid`s - is the intention that `allBidStates` returns the state of the bid after each `BidEvent` has been applied?