### PR TITLE
Update auction spec

### DIFF
--- a/mcd/auctions.md
+++ b/mcd/auctions.md
@@ -76,6 +76,7 @@ Bids are created on `kick` and updated with every subsequent bid event.
 | Flipper.deal   | DSNote    | Flipper.bids[e.id]  | BidEvent        |
 | Flipper.yank   | DSNote    | Flipper.bids[e.id]  | BidEvent        |
 | Flopper.kick   | Kick      | Flopper.bids[e.id]  | BidEvent        |
+| Flopper.tick   | DSNote    | Flopper.bids[e.id]  | BidEvent        |
 | Flopper.dent   | DSNote    | Flopper.bids[e.id]  | BidEvent        |
 | Flopper.deal   | DSNote    | Flopper.bids[e.id]  | BidEvent        |
 | Flopper.yank   | DSNote    | Flopper.bids[e.id]  | BidEvent        |

--- a/mcd/auctions.md
+++ b/mcd/auctions.md
@@ -76,7 +76,7 @@ Bids are created on `kick` and updated with every subsequent bid event.
 | Flipper.deal   | DSNote    | Flipper.bids[e.id]  | BidEvent        |
 | Flipper.yank   | DSNote    | Flipper.bids[e.id]  | BidEvent        |
 | Flopper.kick   | Kick      | Flopper.bids[e.id]  | BidEvent        |
-| Flopper.tend   | DSNote    | Flopper.bids[e.id]  | BidEvent        |
+| Flopper.dent   | DSNote    | Flopper.bids[e.id]  | BidEvent        |
 | Flopper.deal   | DSNote    | Flopper.bids[e.id]  | BidEvent        |
 | Flopper.yank   | DSNote    | Flopper.bids[e.id]  | BidEvent        |
 | Flapper.kick   | Kick      | Flapper.bids[e.id]  | BidEvent        |


### PR DESCRIPTION
I noticed a minor bug with the auction spec (`Flopper.tend` -> `Flopper.dent`) and I have a PR that will likely be merged shortly to add `Flopper.tick`, so I included that here as it would also be a `DSNote` `BidEvent`