### PR TITLE
Add ManagedCdp.created to spec

### DIFF
--- a/cdp-manager.graphql
+++ b/cdp-manager.graphql
@@ -1,10 +1,11 @@
 type ManagedCdp {
-  usr:   Address # account owner - public key
-  id:    Integer # cdp manager identifier
-  urnId: String  # urn identifier
-  urn:   Urn     # urn object
-  ilkId: String  # ilk identifier
-  ilk:   Ilk     # ilk object
+  usr:     Address  # account owner - public key
+  id:      Integer  # cdp manager identifier
+  urnId:   String   # urn identifier
+  urn:     Urn      # urn object
+  ilkId:   String   # ilk identifier
+  ilk:     Ilk      # ilk object
+  created: DateTime # derived from NewCdp event
 }
 
 type Query {


### PR DESCRIPTION
This would be a nice easy-to-use way of adding the timestamp from the NewCdp event into the spec--hope it's not too complicated to implement. But like I mentioned on the call, this is just a nice-to-have, since we can use the time of the first frob event as well.