### PR TITLE
remove getManagedCdp(usr)

### DIFF
--- a/cdp-manager.graphql
+++ b/cdp-manager.graphql
@@ -21,10 +21,6 @@ type Query {
    ): [ManagedCdp]
 
    getManagedCdp(
-     usr: Address
-   ): ManagedCdp
-
-   getManagedCdp(
      id: Integer
    ): ManagedCdp
 


### PR DESCRIPTION
This is redundant with allManagedCdps, assuming that ManagedCdpFilter can filter by usr