### PR TITLE
Replace allBidEvents with more specific queries

### DIFF
--- a/mcd/auctions.md
+++ b/mcd/auctions.md
@@ -141,7 +141,7 @@ type Query {
      blockNumber: Int
    ): Flop
 
-   allBidEvents(
+   allFlipBidEvents(
      first:     Int,
      last:      Int,
      offset:    Int,
@@ -150,7 +150,28 @@ type Query {
      orderBy:   BidEventOrderBy,
      condition: BidEventCondition,
      filter:    BidEventFilter
-   ): [BidEvent]
+   ): [BidEvent] # the bid field on these events are flips
 
+   allFlapBidEvents(
+     first:     Int,
+     last:      Int,
+     offset:    Int,
+     before:    Cursor,
+     after:     Cursor,
+     orderBy:   BidEventOrderBy,
+     condition: BidEventCondition,
+     filter:    BidEventFilter
+   ): [BidEvent] # the bid field on these events are flaps
+
+   allFlopBidEvents(
+     first:     Int,
+     last:      Int,
+     offset:    Int,
+     before:    Cursor,
+     after:     Cursor,
+     orderBy:   BidEventOrderBy,
+     condition: BidEventCondition,
+     filter:    BidEventFilter
+   ): [BidEvent] # the bid field on these events are flops
 }
 ```


### PR DESCRIPTION
There's significant additional overhead/complexity in attempting to implement `allBidEvents` in Postgraphile with dynamic `Bid` types (ie returning a `Flap` in the bid field for flap bid events, `Flop` for flop bid events, and `Flip` for flip bid events) because each of these bid types are a little different (ie Flip has tab, ilk, and urn). 

Lawrence said it was okay to implement `allFlapBidEvents` + `allFlopBidEvents` + `allFlipBidEvents` instead.