### PR TITLE
Remove computed ratio/safe from urn state

### DIFF
--- a/mcd/urn.md
+++ b/mcd/urn.md
@@ -8,8 +8,6 @@ type Urn {
   ilk:     Ilk          # ilk object
   ink:     Float        # locked gem
   art:     Float        # outstanding debt
-  ratio:   Float        # collateralization ratio: (ink * ilk.spot) / (art * ilk.rate)
-  safe:    Boolean      # true if sufficiently collateralized (ratio > 1)
   frobs:   [FrobEvent]  # state change events
   bites:   [BiteEvent]  # liquidation events
   created: Datetime


### PR DESCRIPTION
As discussed, these should be computed by the end user, including nuances like when there is no `art` or similar. It feels wrong to replicate logic from the contracts inside the data layer :frowning_woman: 